### PR TITLE
Calling the :strip proc at the end is sufficient

### DIFF
--- a/lib/jeql/graphql_block.rb
+++ b/lib/jeql/graphql_block.rb
@@ -3,7 +3,7 @@ class Jeql::GraphqlBlock < Liquid::Block
 
   def initialize(tag_name, text, tokens)
     super
-    @params = text.strip.split(',').map(&:strip).map{|s| s.gsub(%r!['"]!, '').split(':').map(&:strip)}
+    @params = text.split(',').map{|s| s.gsub(%r!['"]!, '').split(':').map(&:strip)}
     @text = text
   end
 


### PR DESCRIPTION
This avoids unnecessary string allocations from the extra calls to `String#strip` and unnecessary array allocation from the extra `Array#map`