### PR TITLE
Convert array of arrays to a Hash with Hash[]

### DIFF
--- a/lib/jeql/graphql_block.rb
+++ b/lib/jeql/graphql_block.rb
@@ -8,8 +8,7 @@ class Jeql::GraphqlBlock < Liquid::Block
   end
 
   def render(context)
-    hash_params = {}
-    @params.each {|k, v| hash_params[k] = v}
+    hash_params = Hash[@params]
 
     endpoint_config = context.registers[:site].config["jeql"][hash_params["endpoint"]]
     query = Jeql::Query.new(hash_params["query"], context.registers[:site].config["source"], endpoint_config)


### PR DESCRIPTION
Simplifies code by using a core function.

**Warning:** This will raise `ArgumentError` if the tag's markup doesn't result in a Array that can be converted into a Hash.

*FIXME: move this Hash generation into `#initialize` to avoid allocating a new Hash on each call to `#render`*