### PR TITLE
Use regex to extract params for Liquid tag

### DIFF
--- a/lib/jeql/graphql_block.rb
+++ b/lib/jeql/graphql_block.rb
@@ -1,9 +1,10 @@
 class Jeql::GraphqlBlock < Liquid::Block
   GraphQlError = Class.new(Jekyll::Errors::FatalException)
+  PARAMS_SYNTAX = /(\w+):\s*['"](\w+)['"],?/
 
   def initialize(tag_name, text, tokens)
     super
-    @params = text.split(',').map{|s| s.gsub(%r!['"]!, '').split(':').map(&:strip)}
+    @params = text.scan(PARAMS_SYNTAX)
     @text = text
   end
 


### PR DESCRIPTION
Just discovered that *sometimes* using a regex can be faster than multiple method calls.

### Benchmark script
```ruby
# frozen_string_literal: true

require 'benchmark/ips'

INPUT = " endpoint: 'github', query:'last_repos' "
PARAM_SYNTAX = /(\w+):\s*['"](\w+)['"],?/

Benchmark.ips do |x|
  x.report('method chain') { INPUT.split(',').map{|s| s.gsub(%r!['"]!, '').split(':').map(&:strip)} }
  x.report('regex scan') { INPUT.scan(PARAM_SYNTAX) }
  x.compare!
end
```
### Memory profiling
This change is also optimal for memory
```ruby
# frozen_string_literal: true

require 'memory_profiler'

INPUT = " endpoint: 'github', query:'last_repos' "
PARAM_SYNTAX = /(\w+):\s*['"](\w+)['"],?/

# Run the following *individually* to easily grasp difference:
# 
# MemoryProfiler.report { INPUT.split(',').map{|s| s.gsub(%r!['"]!, '').split(':').map(&:strip)} }.pretty_print
# MemoryProfiler.report { INPUT.scan(PARAM_SYNTAX) }.pretty_print
```