### PR TITLE
Give more information when query failed

### DIFF
--- a/lib/jeql/graphql_block.rb
+++ b/lib/jeql/graphql_block.rb
@@ -10,13 +10,11 @@ class Jeql::GraphqlBlock < Liquid::Block
 
   def handleResponse(responseBody)
     begin
-      JSON.parse(responseBody)
+      response = JSON.parse(responseBody)
+      return response.key?("message") ? "Endpoint responded: \"#{response['message']}\"" : ""
     rescue JSON::ParserError => e
       return ""
     end
-    responseBody = JSON.parse(query.response.body)
-
-    return responseBody.key?("message") ? "Endpoint responded: \"#{responseBody['message']}\"" : ""
   end
 
   def render(context)

--- a/lib/jeql/graphql_block.rb
+++ b/lib/jeql/graphql_block.rb
@@ -17,7 +17,9 @@ class Jeql::GraphqlBlock < Liquid::Block
       context['data'] = JSON.parse(query.response.body)['data']
       super
     else
-      raise GraphQlError, "The query #{query.query_name} failed"
+      responseBody = JSON.parse(query.response.body)
+      message = responseBody.key?("message") ? "Endpoint responded: #{responseBody['message']}" : ""
+      raise GraphQlError, "The query #{query.query_name} failed. " + message 
     end
   end
 end


### PR DESCRIPTION
	- Updated query response failure to be more verbose

2 things to note about this PR:

- I am not a Ruby dev so I couldn't figure out how to add newlines in the error message, or use best practises
- This is quite possibly only applicable to Github requests, an assumption is made that Gql will only return JSON though, and I check for the appropriate key 'message' safely, so I think it is a a safe implementation, maybe you can comment
